### PR TITLE
Fix css compile issue in build mode

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,7 +158,8 @@ module.exports = function(grunt) {
       build: {
         options: {
           client: false,
-          pretty: true
+          pretty: true,
+          data: { front_end_build: true }
         },
         files: {
           'public/templates/footer_scripts.html': 'lib/views/footer_scripts.jade',

--- a/lib/views/header_styles.jade
+++ b/lib/views/header_styles.jade
@@ -5,4 +5,4 @@ if process.env.NODE_ENV === 'dev' || front_end_build === true
   link(type="text/css", rel="stylesheet", href="/css/main.css")
   // endbuild
 else
-  link(href="/css/main.css")
+  link(type="text/css", rel="stylesheet", href="/css/main.css")

--- a/lib/views/header_styles.jade
+++ b/lib/views/header_styles.jade
@@ -1,3 +1,8 @@
-// build:css /dist/css/main.css
-link(type="text/css", rel="stylesheet", href="/css/main.css")
-// endbuild
+if process.env.NODE_ENV === 'dev' || front_end_build === true
+  // build:css /dist/css/main.css
+  link(type="text/css", rel="stylesheet", href="/bower_components/Font-Awesome/css/font-awesome.css")
+  link(type="text/css", rel="stylesheet", href="/bower_components/pure/pure.css")
+  link(type="text/css", rel="stylesheet", href="/css/main.css")
+  // endbuild
+else
+  link(href="/css/main.css")


### PR DESCRIPTION
when I was fixing css path issue in _branch fix-css-path-issue-in-build-mode_, I didn't check it in UAT server. Actually, I missed something that the _useminPrepare_ job would not update the html file to target.

when we are doing the css and js minification operation using _useminPrepare_ and _usemin_, we expect

``` jade
// build:css /dist/css/main.css
link(type="text/css", rel="stylesheet", href="/bower_components/Font-Awesome/css/font-awesome.css")
link(type="text/css", rel="stylesheet", href="/bower_components/pure/pure.css")
link(type="text/css", rel="stylesheet", href="/css/main.css")
// endbuild
```

to be compiled to 

``` jade
link(type="text/css", rel="stylesheet", href="/css/main.css")
```

but the template is a backend template, which should be compiled from backend, so add condition

``` js
if process.env.NODE_ENV === 'dev' || front_end_build === true
```

to verify if it should be compiled.
